### PR TITLE
Allow newer version of tornado/APScheduler

### DIFF
--- a/ndscheduler/server/handlers/audit_logs.py
+++ b/ndscheduler/server/handlers/audit_logs.py
@@ -36,14 +36,14 @@ class Handler(base.BaseHandler):
         """
         return self._get_logs()
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get_logs_yield(self):
         return_json = yield self.get_logs()
         self.finish(return_json)
 
     @tornado.web.removeslash
     @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get(self):
         """Returns audit logs.
 

--- a/ndscheduler/server/handlers/audit_logs.py
+++ b/ndscheduler/server/handlers/audit_logs.py
@@ -36,14 +36,12 @@ class Handler(base.BaseHandler):
         """
         return self._get_logs()
 
-    @tornado.gen.coroutine
-    def get_logs_yield(self):
+    async def get_logs_yield(self):
         return_json = yield self.get_logs()
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.gen.coroutine
-    def get(self):
+    async def get(self):
         """Returns audit logs.
 
         Handles the endpoint GET /api/v1/logs.

--- a/ndscheduler/server/handlers/audit_logs.py
+++ b/ndscheduler/server/handlers/audit_logs.py
@@ -42,7 +42,6 @@ class Handler(base.BaseHandler):
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
         """Returns audit logs.

--- a/ndscheduler/server/handlers/executions.py
+++ b/ndscheduler/server/handlers/executions.py
@@ -42,8 +42,7 @@ class Handler(base.BaseHandler):
         """
         return self._get_execution(execution_id)
 
-    @tornado.gen.coroutine
-    def get_execution_yield(self, execution_id):
+    async def get_execution_yield(self, execution_id):
         """Wrapper for get_execution to run in async mode
 
         :param str execution_id: Execution id.
@@ -77,15 +76,13 @@ class Handler(base.BaseHandler):
         """
         return self._get_executions()
 
-    @tornado.gen.coroutine
-    def get_executions_yield(self):
+    async def get_executions_yield(self):
         """Wrapper for get_executions to run in async mode."""
         return_json = yield self.get_executions()
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.gen.coroutine
-    def get(self, execution_id=None):
+    async def get(self, execution_id=None):
         """Returns a execution or multiple executions.
 
         Handles two endpoints:
@@ -145,8 +142,7 @@ class Handler(base.BaseHandler):
         """
         return self._run_job(job_id)
 
-    @tornado.gen.coroutine
-    def run_job_yield(self, job_id):
+    async def run_job_yield(self, job_id):
         """Wrapper for run_job to run in async mode.
 
         :param str job_id:
@@ -156,8 +152,7 @@ class Handler(base.BaseHandler):
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.gen.coroutine
-    def post(self, job_id):
+    async def post(self, job_id):
         """Runs a job.
 
         Handles an endpoint:

--- a/ndscheduler/server/handlers/executions.py
+++ b/ndscheduler/server/handlers/executions.py
@@ -84,7 +84,6 @@ class Handler(base.BaseHandler):
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self, execution_id=None):
         """Returns a execution or multiple executions.
@@ -157,7 +156,6 @@ class Handler(base.BaseHandler):
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def post(self, job_id):
         """Runs a job.

--- a/ndscheduler/server/handlers/executions.py
+++ b/ndscheduler/server/handlers/executions.py
@@ -42,7 +42,7 @@ class Handler(base.BaseHandler):
         """
         return self._get_execution(execution_id)
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get_execution_yield(self, execution_id):
         """Wrapper for get_execution to run in async mode
 
@@ -77,7 +77,7 @@ class Handler(base.BaseHandler):
         """
         return self._get_executions()
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get_executions_yield(self):
         """Wrapper for get_executions to run in async mode."""
         return_json = yield self.get_executions()
@@ -85,7 +85,7 @@ class Handler(base.BaseHandler):
 
     @tornado.web.removeslash
     @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get(self, execution_id=None):
         """Returns a execution or multiple executions.
 
@@ -146,7 +146,7 @@ class Handler(base.BaseHandler):
         """
         return self._run_job(job_id)
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def run_job_yield(self, job_id):
         """Wrapper for run_job to run in async mode.
 
@@ -158,7 +158,7 @@ class Handler(base.BaseHandler):
 
     @tornado.web.removeslash
     @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def post(self, job_id):
         """Runs a job.
 

--- a/ndscheduler/server/handlers/jobs.py
+++ b/ndscheduler/server/handlers/jobs.py
@@ -19,6 +19,7 @@ class Handler(base.BaseHandler):
         It's a blocking operation.
         """
         jobs = self.scheduler_manager.get_jobs()
+        print(jobs)
         return_json = []
         for job in jobs:
             return_json.append(self._build_job_dict(job))
@@ -58,8 +59,7 @@ class Handler(base.BaseHandler):
         """
         return self._get_jobs()
 
-    @tornado.gen.coroutine
-    def get_jobs_yield(self):
+    async def get_jobs_yield(self):
         """Wrapper for get_jobs in async mode."""
         return_json = yield self.get_jobs()
         self.finish(return_json)
@@ -90,8 +90,7 @@ class Handler(base.BaseHandler):
         """
         return self._get_job(job_id)
 
-    @tornado.gen.coroutine
-    def get_job_yield(self, job_id):
+    async def get_job_yield(self, job_id):
         """Wrapper for get_job() to run in async mode.
 
         :param str job_id: Job id.
@@ -100,8 +99,7 @@ class Handler(base.BaseHandler):
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.gen.coroutine
-    def get(self, job_id=None):
+    async def get(self, job_id=None):
         """Returns a job or multiple jobs.
 
         Handles two endpoints:
@@ -159,13 +157,11 @@ class Handler(base.BaseHandler):
         """Wrapper for _delete_job() to run on a threaded executor."""
         self._delete_job(job_id)
 
-    @tornado.gen.coroutine
-    def delete_job_yield(self, job_id):
+    async def delete_job_yield(self, job_id):
         yield self.delete_job(job_id)
 
     @tornado.web.removeslash
-    @tornado.gen.coroutine
-    def delete(self, job_id):
+    async def delete(self, job_id):
         """Deletes a job.
 
         Handles an endpoint:
@@ -245,8 +241,7 @@ class Handler(base.BaseHandler):
         """
         self._modify_job(job_id)
 
-    @tornado.gen.coroutine
-    def modify_job_yield(self, job_id):
+    async def modify_job_yield(self, job_id):
         """Wrapper for modify_job() to run in async mode.
 
         :param str job_id: Job id.
@@ -254,8 +249,7 @@ class Handler(base.BaseHandler):
         yield self.modify_job(job_id)
 
     @tornado.web.removeslash
-    @tornado.gen.coroutine
-    def put(self, job_id):
+    async def put(self, job_id):
         """Modifies a job.
 
         Handles an endpoint:

--- a/ndscheduler/server/handlers/jobs.py
+++ b/ndscheduler/server/handlers/jobs.py
@@ -58,7 +58,7 @@ class Handler(base.BaseHandler):
         """
         return self._get_jobs()
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get_jobs_yield(self):
         """Wrapper for get_jobs in async mode."""
         return_json = yield self.get_jobs()
@@ -90,7 +90,7 @@ class Handler(base.BaseHandler):
         """
         return self._get_job(job_id)
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get_job_yield(self, job_id):
         """Wrapper for get_job() to run in async mode.
 
@@ -101,7 +101,7 @@ class Handler(base.BaseHandler):
 
     @tornado.web.removeslash
     @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get(self, job_id=None):
         """Returns a job or multiple jobs.
 
@@ -160,13 +160,13 @@ class Handler(base.BaseHandler):
         """Wrapper for _delete_job() to run on a threaded executor."""
         self._delete_job(job_id)
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def delete_job_yield(self, job_id):
         yield self.delete_job(job_id)
 
     @tornado.web.removeslash
     @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def delete(self, job_id):
         """Deletes a job.
 
@@ -247,7 +247,7 @@ class Handler(base.BaseHandler):
         """
         self._modify_job(job_id)
 
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def modify_job_yield(self, job_id):
         """Wrapper for modify_job() to run in async mode.
 
@@ -257,7 +257,7 @@ class Handler(base.BaseHandler):
 
     @tornado.web.removeslash
     @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def put(self, job_id):
         """Modifies a job.
 

--- a/ndscheduler/server/handlers/jobs.py
+++ b/ndscheduler/server/handlers/jobs.py
@@ -100,7 +100,6 @@ class Handler(base.BaseHandler):
         self.finish(return_json)
 
     @tornado.web.removeslash
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self, job_id=None):
         """Returns a job or multiple jobs.
@@ -165,7 +164,6 @@ class Handler(base.BaseHandler):
         yield self.delete_job(job_id)
 
     @tornado.web.removeslash
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def delete(self, job_id):
         """Deletes a job.
@@ -256,7 +254,6 @@ class Handler(base.BaseHandler):
         yield self.modify_job(job_id)
 
     @tornado.web.removeslash
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def put(self, job_id):
         """Modifies a job.

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'APScheduler >= 3.0.0',
         'SQLAlchemy >= 1.0.0',
         'future >= 0.15.2',
-        'tornado < 6',
+        'tornado > 6',
         'python-dateutil >= 2.2',
     ],
     classifiers=classifiers,


### PR DESCRIPTION
Latest version of APScheduler is 3.8. Will see if it can resolve the dependencies without breaking.
Prefect >= 0.15.5 requires Tornado >= 6.0.2